### PR TITLE
Use Django admin base_site templates

### DIFF
--- a/sp/templates/sp/error.html
+++ b/sp/templates/sp/error.html
@@ -1,22 +1,15 @@
+{% extends "admin/base_site.html" %}
 {% load i18n %}
 
-<html>
-<head>
-    <title>{% trans "SSO Error" %} - {{ idp }}</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
-</head>
-<body>
-    <div class="container">
-        <h1 class="mt-2 mb-4 pb-2 border-bottom">{% trans "SSO Error" %}</h1>
-        <p>{{ reason }}</p>
-        <p>{% trans "State" %}: <code>{{ state }}</code></p>
-        {% if errors %}
-            <ul>
-                {% for err in errors %}
-                    <li>{{ err }}</li>
-                {% endfor %}
-            </ul>
-        {% endif %}
-    </div>
-</body>
-</html>
+{% block content %}
+    <h1>{% trans "SSO Error" %}</h1>
+    <p>{{ reason }}</p>
+    <p>{% trans "State" %}: <code>{{ state }}</code></p>
+    {% if errors %}
+        <ul>
+            {% for err in errors %}
+                <li>{{ err }}</li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+{% endblock %}

--- a/sp/templates/sp/test.html
+++ b/sp/templates/sp/test.html
@@ -1,46 +1,33 @@
+{% extends "admin/base_site.html" %}
 {% load i18n %}
 
-<html>
-<head>
-    <title>{% trans "IdP Test" %} - {{ idp }}</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
-</head>
-<body>
-    <div class="container">
-        <div class="pb-1 mt-4 mb-4 border-bottom">
-            <h1>{{ idp }}</h1>
-        </div>
+{% block content %}
+    <h1>{% trans "IdP Test" %} - {{ idp }}</h1>
+    <dl>
+        <dt>{% trans "Name ID Format" %}</dt>
+        <dd>{{ nameid_format }}</dd>
 
-        <dl class="mb-4">
-            <dt>{% trans "Name ID Format" %}</dt>
-            <dd>{{ nameid_format }}</dd>
-
-            <dt>{% trans "Name ID" %}</dt>
-            <dd>{{ nameid }}</dd>
-        </dl>
-
-        <div class="table-responsive">
-            <table class="table table-bordered">
-                <thead>
-                    <tr>
-                        <th>{% trans "SAML Attribute" %}</th>
-                        <th>{% trans "Mapped Name" %}</th>
-                        <th>{% trans "NameID" %}</th>
-                        <th>{% trans "Value" %}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for attr, value in attrs %}
-                        <tr>
-                            <td>{{ attr.saml_attribute }}</td>
-                            <td>{{ attr.mapped_name }}</td>
-                            <td>{% if attr.is_nameid %}&#10004;{% endif %}</td>
-                            <td>{{ value }}</td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-    </div>
-</body>
-</html>
+        <dt>{% trans "Name ID" %}</dt>
+        <dd>{{ nameid }}</dd>
+    </dl>
+    <table>
+        <thead>
+        <tr>
+            <th>{% trans "SAML Attribute" %}</th>
+            <th>{% trans "Mapped Name" %}</th>
+            <th>{% trans "NameID" %}</th>
+            <th>{% trans "Value" %}</th>
+        </tr>
+        </thead>
+        <tbody>
+        {% for attr, value in attrs %}
+            <tr>
+                <td>{{ attr.saml_attribute }}</td>
+                <td>{{ attr.mapped_name }}</td>
+                <td>{% if attr.is_nameid %}&#10004;{% endif %}</td>
+                <td>{{ value }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+{% endblock %}

--- a/sp/templates/sp/unauth.html
+++ b/sp/templates/sp/unauth.html
@@ -1,15 +1,9 @@
+{% extends "admin/base_site.html" %}
 {% load i18n %}
 
-<html>
-<head>
-    <title>{% trans "Authentication Error" %} - {{ idp }}</title>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
-</head>
-<body>
-    <div class="container">
-        <h1 class="mt-2 mb-4 pb-2 border-bottom">{% if verify %}{% trans "Verification Error" %}{% else %}{% trans "Authentication Error" %}{% endif %}</h1>
-        <p>{% blocktrans with nameid=nameid %}Could not authenticate user "{{ nameid }}".{% endblocktrans %}</p>
-        {% if verify %}<p>{% blocktrans with user=user %}Expected verification credentials for "{{ user }}".{% endblocktrans %}</p>{% endif %}
-    </div>
-</body>
-</html>
+{% block content %}
+    <h1>{% if verify %}{% trans "Verification Error" %}{% else %}{% trans "Authentication Error" %}{% endif %}</h1>
+    <p>{% blocktrans with nameid=nameid %}Could not authenticate user "{{ nameid }}".{% endblocktrans %}</p>
+    {% if verify %}<p>{% blocktrans with user=user %}Expected verification credentials for "{{ user }}".{% endblocktrans %}</p>{% endif %}
+{% endblock %}
+{% load i18n %}


### PR DESCRIPTION
Removes a bootstrap dependency and uses the Django admin base_site template for IdP test and error pages