### PR TITLE
Switch cert signing algorithm to SHA2_256

### DIFF
--- a/sp/models.py
+++ b/sp/models.py
@@ -257,7 +257,7 @@ class IdP(models.Model):
             .not_valid_before(now)
             .not_valid_after(self.certificate_expires)
             .add_extension(basic_contraints, critical=False)
-            .sign(key, hashes.SHA2_256(), backend)
+            .sign(key, hashes.SHA256(), backend)
         )
         self.x509_certificate = cert.public_bytes(serialization.Encoding.PEM).decode(
             "ascii"


### PR DESCRIPTION
SHA1 is no longer supported in python 3.11.  Recommend switching to SHA2_256